### PR TITLE
Update package.json for new main.js location

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-markdown-editor",
   "version": "1.0.2",
-  "main": "main.js",
+  "main": "lib/main.js",
   "scripts": {
     "test": "npm run test:prettier && jest",
     "prettier-all": "prettier --write --single-quote --jsx-bracket-same-line --trailing-comma all --print-width 100  `find lib -name \"*.js\"`",


### PR DESCRIPTION
iOS Bundling failed:
While trying to resolve module `react-native-markdown-editor` from file `/__/__/__/__/components/Compose/Views/Block.js`, the package `/__/__/__/__/node_modules/react-native-markdown-editor/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`/__/__/__/__/node_modules/react-native-markdown-editor/main.js`.